### PR TITLE
fixing undefined variable reference

### DIFF
--- a/review-question-3.rb
+++ b/review-question-3.rb
@@ -7,7 +7,7 @@ sophie = User.new("Sophie")
 sandwich_photo.user = sophie
 sandwich_photo.user.name
 # => "Sophie"
-user.photos
+sophie.photos
 # => [#<Photo:0x00007fae2880b370>]
 
 


### PR DESCRIPTION
When this was `user` students were confused whether they should build `.photos` as an instance method or a class method like `User.photos`. Renaming `user` to `sophie` to refer to existing variable and clear ambiguity.